### PR TITLE
updated-dependencies

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,13 +5,13 @@ repositories {
 }
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.3'
+    compileSdkVersion 26
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.razorpay.newsampleapp"
         minSdkVersion 19
-        targetSdkVersion 25
+        targetSdkVersion 26
     }
 
     buildTypes {
@@ -27,6 +27,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.razorpay:checkout:1.4.9'
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'com.razorpay:checkout:1.4.9'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@
 
 buildscript {
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 30 12:13:25 IST 2017
+#Sat Nov 17 02:20:07 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip


### PR DESCRIPTION
1. updated the compile and target version because the Google Play requires the apps target API level 26 or higher
2. In build.gradle changed from compile to implementation,because the compile is now deprecated.
3. Updated the wrapper.properties from 4.1 to 4.8